### PR TITLE
fix: Avoid syntax error

### DIFF
--- a/.pre-commit-entry.sh
+++ b/.pre-commit-entry.sh
@@ -7,7 +7,7 @@ if ! command -v nix-build; then
   exit 1
 fi
 
-if !command -v nix-instantiate; then
+if ! command -v nix-instantiate; then
   echo 'ERROR: this pre-commit hook requires "nix-instantiate" to be installed first'
   exit 1
 fi


### PR DESCRIPTION
`!command` is a syntax error, so this check will always "pass".